### PR TITLE
feat(mypy): use typing_extensions.ParamSpec for decorator typing

### DIFF
--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -9,10 +9,13 @@ from typing import (
     TypeVar,
 )
 
+from typing_extensions import ParamSpec
+
 from .types import (
     is_text,
 )
 
+P = ParamSpec("P")
 T = TypeVar("T")
 
 
@@ -68,7 +71,7 @@ def _validate_supported_kwarg(kwargs: Any) -> None:
         )
 
 
-def validate_conversion_arguments(to_wrap: Callable[..., T]) -> Callable[..., T]:
+def validate_conversion_arguments(to_wrap: Callable[P, T]) -> Callable[P, T]:
     """
     Validates arguments for conversion functions.
     - Only a single argument is present
@@ -77,7 +80,7 @@ def validate_conversion_arguments(to_wrap: Callable[..., T]) -> Callable[..., T]
     """
 
     @functools.wraps(to_wrap)
-    def wrapper(*args: Any, **kwargs: Any) -> T:
+    def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
         _assert_one_val(*args, **kwargs)
         if kwargs:
             _validate_supported_kwarg(kwargs)
@@ -108,15 +111,15 @@ def return_arg_type(at_position: int) -> Callable[..., Callable[..., T]]:
 
 def replace_exceptions(
     old_to_new_exceptions: Dict[Type[BaseException], Type[BaseException]]
-) -> Callable[[Callable[..., T]], Callable[..., T]]:
+) -> Callable[[Callable[P, T]], Callable[P, T]]:
     """
     Replaces old exceptions with new exceptions to be raised in their place.
     """
     old_exceptions = tuple(old_to_new_exceptions.keys())
 
-    def decorator(to_wrap: Callable[..., T]) -> Callable[..., T]:
+    def decorator(to_wrap: Callable[P, T]) -> Callable[P, T]:
         @functools.wraps(to_wrap)
-        def wrapped(*args: Any, **kwargs: Any) -> T:
+        def wrapped(*args: P.args, **kwargs: P.kwargs) -> T:
             try:
                 return to_wrap(*args, **kwargs)
             except old_exceptions as err:

--- a/eth_utils/decorators.py
+++ b/eth_utils/decorators.py
@@ -13,7 +13,6 @@ from .types import (
     is_text,
 )
 
-
 T = TypeVar("T")
 
 


### PR DESCRIPTION
### What was wrong?

More modern versions of python support ParamSpec in the typing module. This PR implements proper decorator typing with ParamSpec in all python versions that support it, and falls back to the current behavior on python versions that don't.

Related to Issue # N/A
Closes # N/A

### How was it fixed?
Conditional definitions based on whether or not typing module has ParamSpec defined

### Todo:

- [x] Clean up commit history
- [x] Add or update documentation related to these changes
- [x] Add entry to the [release notes](https://github.com/ethereum/eth-utils/blob/main/newsfragments/README.md)

I did not update docs or release notes as I don't think its necessary for this type of change. Let me know if you disagree and I can do so. 

#### Cute Animal Picture

![Put a link to a cute animal picture inside the parenthesis-->](https://github.com/user-attachments/assets/6088f5f2-329c-4b1f-a07c-190c2944eba8)

